### PR TITLE
Update Jinja2 to 2.10.1

### DIFF
--- a/opensource_requirements.txt
+++ b/opensource_requirements.txt
@@ -6,7 +6,7 @@ python-dateutil==2.6.1
 PyYAML==3.12
 statsd==3.2.2
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==1.0
 six==1.11.0
 Werkzeug==0.14.1


### PR DESCRIPTION
In Pallets Jinja before 2.10.1, str.format_map allows a sandbox escape.