### PR TITLE
fix CVE-2019-14806

### DIFF
--- a/opensource_requirements.txt
+++ b/opensource_requirements.txt
@@ -9,7 +9,7 @@ statsd==3.3
 itsdangerous==1.1.0
 MarkupSafe==1.1.1
 six==1.12.0
-Werkzeug==0.14.1
+Werkzeug==0.15.5
 marshmallow==2.19.0
 webargs==5.1.3
 apispec==1.1.0


### PR DESCRIPTION
Vulnerability details: https://nvd.nist.gov/vuln/detail/CVE-2019-14806

What was affected?
- One of the opensource requirements **werkzeug** was affected and now updated to the fixed version